### PR TITLE
Get projectName internally

### DIFF
--- a/src/gdext/env.nim
+++ b/src/gdext/env.nim
@@ -4,6 +4,7 @@ This project must be compiled as a dynamic library.
 Instead, run `nimble build --app:lib` or append `--app: lib` to the config.nims file.
 """.}
 
-import std/strutils
-const projectName {.strdefine.} = "anonymous"
-const ExtensionMainName* = projectName.capitalizeAscii
+import std/[strutils, os, macros]
+const workspacePath* = getProjectPath()
+const workspaceName* = workspacePath.splitFile.name
+const ExtensionMainName* {.strdefine.} = workspaceName.capitalizeAscii


### PR DESCRIPTION
Change projectName to be taken from the Nim build system, so that it does not need to be specified in bootstrapconf.nims.